### PR TITLE
fix(py3): explicit __hash__ required

### DIFF
--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -349,7 +349,7 @@ class Document(object):
 
     def __init__(self, client, did, json=None):
         self.client = client
-        self.did = did
+        self._did = did
         self._fetched = False
         self._deleted = False
         self._load(json)
@@ -357,20 +357,14 @@ class Document(object):
     def __eq__(self, other_doc):
         """
         equals `==` operator overload
-
-        It doesn't matter the order of the urls list. What matters is the
-        existence of the urls are the same on both sides.
         """
-        return self._sorted_doc == other_doc._sorted_doc
+        return self.did == other_doc.did
 
     def __ne__(self, other_doc):
         """
         not equals `!=` operator overload
-
-        It doesn't matter the order of the urls list. What matters is the
-        existence of the urls are the same on both sides.
         """
-        return self._sorted_doc != other_doc._sorted_doc
+        return self.did != other_doc.did
 
     def __hash__(self):
         return hash(self.did)
@@ -426,6 +420,10 @@ class Document(object):
         to be updated
         """
         return {k:v for k,v in self._doc.items() if k in UPDATABLE_ATTRS}
+
+    @property
+    def did(self):
+        return self._did
 
     @property
     def _doc(self):

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -349,7 +349,7 @@ class Document(object):
 
     def __init__(self, client, did, json=None):
         self.client = client
-        self._did = did
+        self.did = did
         self._fetched = False
         self._deleted = False
         self._load(json)
@@ -420,10 +420,6 @@ class Document(object):
         to be updated
         """
         return {k:v for k,v in self._doc.items() if k in UPDATABLE_ATTRS}
-
-    @property
-    def did(self):
-        return self._did
 
     @property
     def _doc(self):

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -373,7 +373,7 @@ class Document(object):
         return self._sorted_doc != other_doc._sorted_doc
 
     def __hash__(self):
-        return hash(repr(self))
+        return hash(self.did)
 
     def __lt__(self, other_doc):
         return self.did < other_doc.did

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -372,6 +372,9 @@ class Document(object):
         """
         return self._sorted_doc != other_doc._sorted_doc
 
+    def __hash__(self):
+        return hash(repr(self))
+
     def __lt__(self, other_doc):
         return self.did < other_doc.did
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='indexclient',
-    version='1.5.11',
+    version='2.0.0',
     packages=[
         'indexclient',
         'indexclient.parsers',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from indexd_test_utils import (
     auth_driver,
     create_indexd_tables,
     index_driver,
+    indexd_admin_user,
     indexd_client,
     indexd_server,
     setup_indexd_test_database,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from indexd_test_utils import (
     auth_driver,
     create_indexd_tables,
     index_driver,
-    indexd_admin_user,
     indexd_client,
     indexd_server,
     setup_indexd_test_database,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 
 from indexclient.client import Document, recursive_sort
 
@@ -6,6 +7,8 @@ from indexclient.client import Document, recursive_sort
 def create_document(
         did=None, hashes=None, size=None, file_name=None, acl=None,
         urls=None, urls_metadata=None):
+
+    did = str(uuid.uuid4()) if did is None else did
 
     return Document(None, did, json={
         'hashes': hashes or {},
@@ -22,13 +25,8 @@ def create_document(
 
 
 def test_equals():
-    doc1 = create_document()
-    doc2 = create_document()
-    assert doc1 == doc2
-
-    # Out of order values are still equal because the contents are the same.
-    doc1.acl = ['4', '5']
-    doc2.acl = ['5', '4']
+    doc1 = create_document(did='11111111-1111-1111-1111-111111111111')
+    doc2 = create_document(did='11111111-1111-1111-1111-111111111111')
     assert doc1 == doc2
 
 
@@ -38,9 +36,10 @@ def test_not_equals():
     assert doc1 != doc2
 
 
-def test_less_than():
+def test_greater_than_less_than():
     doc1 = create_document(did='11111111-1111-1111-1111-111111111111')
     doc2 = create_document(did='11111111-1111-1111-1111-111111111112')
+    assert doc2 > doc1
     assert doc1 < doc2
 
     # reverse order docs
@@ -49,22 +48,10 @@ def test_less_than():
         for suffix in range(10, 0, -1)
     ]
     # sorted() sorts it in order from lowest to highest did because of __lt__/__gt__
-    assert sorted(docs) == docs[::-1]
-
-
-def test_greater_than():
-    doc1 = create_document(did='11111111-1111-1111-1111-111111111111')
-    doc2 = create_document(did='11111111-1111-1111-1111-111111111112')
-    assert doc2 > doc1
-
-    # reverse order docs
-    docs = [
-        create_document(did='11111111-1111-1111-1111-11111111111' + str(suffix))
-        for suffix in range(10, 0, -1)
-    ]
-    # sorted() sorts it in order from lowest to highest did because of __lt__/__gt__
-    assert sorted(docs) == docs[::-1]
-
+    did = sorted(docs)[0].did
+    for doc in sorted(docs)[1:]:
+        assert doc.did > did
+        did = doc.did
 
 @pytest.mark.parametrize('given, expected', [
     (1, 1),


### PR DESCRIPTION

### Improvements
We make sets of `Document`s in the API (e.g. [here](https://github.com/NCI-GDC/gdcapi/blob/master/gdcapi/resources/download/v0.py#L88)), and in Python3, we have to explicitly implement `__hash__` in order for instances of the class to be hashable. 