### PR TITLE
dev-556: move index_test_utils into indexclient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ docs/_build/
 #venv
 .venv*/
 venv*/
+.python-version
 
 #.swp
 *.swp

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,8 +1,11 @@
 {
-  "version": "1.1.0",
+  "generated_at": "2021-08-02T20:39:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -12,55 +15,42 @@
       "name": "BasicAuthDetector"
     },
     {
+      "name": "CloudantDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3
     },
     {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
     },
     {
       "name": "PrivateKeyDetector"
-    }
-  ],
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "name": "SlackDetector"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
+      "name": "SoftlayerDetector"
     },
     {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+      "name": "StripeDetector"
     },
     {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+      "name": "TwilioKeyDetector"
     }
   ],
   "results": {
@@ -70,24 +60,37 @@
         "filename": "README.md",
         "hashed_secret": "4699f6728b23ee847a94d46c8c88845c0d010810",
         "is_verified": false,
-        "line_number": 83,
-        "is_secret": false
+        "line_number": 83
       },
       {
         "type": "Hex High Entropy String",
         "filename": "README.md",
         "hashed_secret": "44cc59c23214afd591bdc879f8aa22094e39424d",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       },
       {
         "type": "Hex High Entropy String",
         "filename": "README.md",
         "hashed_secret": "b6f6eef3865774de17320e862df503a2bafff715",
         "is_verified": false,
-        "line_number": 85,
-        "is_secret": false
+        "line_number": 85
+      }
+    ],
+    "indexd_test_utils/__init__.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "indexd_test_utils/__init__.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "indexd_test_utils/__init__.py",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 83
       }
     ],
     "tests/test_client.py": [
@@ -96,26 +99,66 @@
         "filename": "tests/test_client.py",
         "hashed_secret": "301918c8b904630da85e75ee32e9ba68ff925b73",
         "is_verified": false,
-        "line_number": 16,
-        "is_secret": false
+        "line_number": 39
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_client.py",
         "hashed_secret": "27860ead00d0b07e86f0819703c8ea31113025a4",
         "is_verified": false,
-        "line_number": 54,
-        "is_secret": false
+        "line_number": 54
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_client.py",
+        "hashed_secret": "b1446dd542cd1725f1c2a1a43905355cd31c039f",
+        "is_verified": false,
+        "line_number": 191
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_client.py",
         "hashed_secret": "cddba27a55fead7ca013f34a28d465f71403af5d",
         "is_verified": false,
-        "line_number": 193,
-        "is_secret": false
+        "line_number": 193
       }
     ]
   },
-  "generated_at": "2021-07-15T19:17:37Z"
+  "version": "1.1.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,7 +10,7 @@ cfgv~=2.0.1
 more-itertools<6
 
 git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.1#egg=indexd
 git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 cdislogging==1.0.0

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,7 +10,7 @@ cfgv~=2.0.1
 more-itertools<6
 
 git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-git+https://github.com/NCI-GDC/indexd.git@feat/dev-556
+git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
 git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 cdislogging==1.0.0

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,7 +10,7 @@ cfgv~=2.0.1
 more-itertools<6
 
 git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-git+https://github.com/NCI-GDC/indexd.git@2.8.0#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@feat/dev-556
 git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 cdislogging==1.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,11 +52,11 @@ cryptography==2.9.2
     # via cdispyutils
 distlib==0.3.1
     # via virtualenv
--git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
+git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
     # via
     #   -r dev-requirements.in
     #   indexd
--git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
     # via
     #   -r dev-requirements.in
     #   indexd

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,23 +4,6 @@
 #
 #    pip-compile --output-file=dev-requirements.txt dev-requirements.in
 #
--e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
-    # via
-    #   -r dev-requirements.in
-    #   cdiserrors
-    #   indexd
--e git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-    # via -r dev-requirements.in
--e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
-    # via
-    #   -r dev-requirements.in
-    #   indexd
--e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
-    # via
-    #   -r dev-requirements.in
-    #   indexd
--e git+https://github.com/NCI-GDC/indexd.git@2.3.1#egg=indexd
-    # via -r dev-requirements.in
 appdirs==1.4.4
     # via virtualenv
 aspy.yaml==1.3.0
@@ -28,9 +11,20 @@ aspy.yaml==1.3.0
 atomicwrites==1.4.0
     # via pytest
 attrs==20.3.0
-    # via pytest
+    # via
+    #   jsonschema
+    #   pytest
+backports.functools-lru-cache==1.6.4
+    # via wcwidth
 cdiserrors==0.1.2
     # via cdispyutils
+cdislogging==1.0.0
+    # via
+    #   -r dev-requirements.in
+    #   cdiserrors
+    #   indexd
+git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
+    # via -r dev-requirements.in
 certifi==2020.12.5
     # via
     #   -c requirements.txt
@@ -47,10 +41,27 @@ chardet==4.0.0
     #   requests
 click==7.1.2
     # via flask
+configparser==4.0.2
+    # via importlib-metadata
+contextlib2==0.6.0.post1
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+    #   zipp
 cryptography==2.9.2
     # via cdispyutils
 distlib==0.3.1
     # via virtualenv
+git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
+    # via
+    #   -r dev-requirements.in
+    #   indexd
+git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+    # via
+    #   -r dev-requirements.in
+    #   indexd
+enum34==1.1.10
+    # via cryptography
 filelock==3.0.12
     # via virtualenv
 flask==1.1.2
@@ -58,8 +69,16 @@ flask==1.1.2
     #   cdiserrors
     #   cdispyutils
     #   indexd
+funcsigs==1.0.2
+    # via
+    #   mock
+    #   pytest
+functools32==3.2.3.post2;python_version=='2.7'
+    # via jsonschema
 future==0.18.2
     # via indexd
+futures==3.3.0;python_version=="2.7"
+    # via pre-commit
 identify==1.6.2
     # via pre-commit
 idna==2.10
@@ -68,6 +87,7 @@ idna==2.10
     #   requests
 importlib-metadata==2.1.1
     # via
+    #   jsonschema
     #   pluggy
     #   pre-commit
     #   pytest
@@ -76,13 +96,15 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-indexclient==2.1.0
-    # via indexd
+git+https://github.com/NCI-GDC/indexd.git@feat/dev-556
+    # via -r dev-requirements.in
+ipaddress==1.0.23
+    # via cryptography
 itsdangerous==1.1.0
     # via flask
 jinja2==2.11.3
     # via flask
-jsonschema==2.6.0
+jsonschema==3.2.0
     # via indexd
 markupsafe==1.1.1
     # via jinja2
@@ -97,7 +119,11 @@ nodeenv==1.5.0
 packaging==20.9
     # via pytest
 pathlib2==2.3.5
-    # via pytest
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+    #   pytest
+    #   virtualenv
 pluggy==0.13.1
     # via pytest
 pre-commit==1.21.0
@@ -112,6 +138,8 @@ pyjwt==1.7.1
     # via cdispyutils
 pyparsing==2.4.7
     # via packaging
+pyrsistent==0.16.1
+    # via jsonschema
 pytest==4.6.11
     # via -r dev-requirements.in
 pyyaml==5.3.1
@@ -124,19 +152,25 @@ requests==2.25.1
     #   cdispyutils
     #   doiclient
     #   dosclient
-    #   indexclient
+scandir==1.10.0
+    # via pathlib2
+singledispatch==3.6.2
+    # via importlib-resources
 six==1.15.0
     # via
     #   cfgv
     #   cryptography
+    #   jsonschema
     #   mock
     #   more-itertools
     #   pathlib2
     #   pre-commit
+    #   pyrsistent
     #   pytest
+    #   singledispatch
     #   sqlalchemy-utils
     #   virtualenv
-sqlalchemy-utils==0.36.5
+sqlalchemy-utils==0.36.3
     # via
     #   -r dev-requirements.in
     #   indexd
@@ -146,6 +180,8 @@ sqlalchemy==1.3.3
     #   sqlalchemy-utils
 toml==0.10.2
     # via pre-commit
+typing==3.7.4.3
+    # via importlib-resources
 urllib3==1.26.4
     # via
     #   -c requirements.txt
@@ -154,11 +190,15 @@ virtualenv==20.4.3
     # via pre-commit
 wcwidth==0.2.5
     # via pytest
-werkzeug==1.0.1
+werkzeug==0.16.1
     # via
     #   cdiserrors
     #   flask
+    #   indexd
 zipp==1.2.0
     # via
     #   importlib-metadata
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -77,7 +77,7 @@ functools32==3.2.3.post2;python_version=='2.7'
     # via jsonschema
 future==0.18.2
     # via indexd
-futures==3.3.0;python_version=="2.7"
+futures==3.3.0;python_version=='2.7'
     # via pre-commit
 identify==1.6.2
     # via pre-commit
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-git+https://github.com/NCI-GDC/indexd.git@feat/dev-556
+git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography
@@ -118,7 +118,7 @@ nodeenv==1.5.0
     # via pre-commit
 packaging==20.9
     # via pytest
-pathlib2==2.3.5
+pathlib2==2.3.6
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,7 +23,7 @@ cdislogging==1.0.0
     #   -r dev-requirements.in
     #   cdiserrors
     #   indexd
-git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
+-e git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
     # via -r dev-requirements.in
 certifi==2020.12.5
     # via
@@ -52,11 +52,11 @@ cryptography==2.9.2
     # via cdispyutils
 distlib==0.3.1
     # via virtualenv
-git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
+-e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
     # via
     #   -r dev-requirements.in
     #   indexd
-git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+-e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
     # via
     #   -r dev-requirements.in
     #   indexd
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
+-e git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,7 +23,7 @@ cdislogging==1.0.0
     #   -r dev-requirements.in
     #   cdiserrors
     #   indexd
--e git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
+git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
     # via -r dev-requirements.in
 certifi==2020.12.5
     # via
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.1#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,11 +52,11 @@ cryptography==2.9.2
     # via cdispyutils
 distlib==0.3.1
     # via virtualenv
--e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
+-git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
     # via
     #   -r dev-requirements.in
     #   indexd
--e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+-git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
     # via
     #   -r dev-requirements.in
     #   indexd
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
--e git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@feat/dev-556#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -1,3 +1,7 @@
+# Note: Some of the code below is also found in indexd client.py
+# https://github.com/NCI-GDC/indexd/tree/master/indexd/client.py.
+# Changes to this code might also require changes to indexd
+
 try:
     from urlparse import urljoin
 except ImportError:

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -1,7 +1,3 @@
-# Note: Some of the code below is also found in indexd client.py
-# https://github.com/NCI-GDC/indexd/tree/master/indexd/client.py.
-# Changes to this code might also require changes to indexd
-
 try:
     from urlparse import urljoin
 except ImportError:

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -1,0 +1,263 @@
+import hashlib
+import random
+import uuid
+import threading
+import pytest
+import requests
+
+from indexclient.client import Document, IndexClient
+from indexd import get_app
+from indexd.alias.drivers.alchemy import (
+    Base as alias_base,
+    SQLAlchemyAliasDriver,
+)
+from indexd.auth.drivers.alchemy import Base as auth_base, SQLAlchemyAuthDriver
+from indexd.index.drivers.alchemy import (
+    Base as index_base,
+    SQLAlchemyIndexDriver,
+)
+from indexd.utils import setup_database, try_drop_test_data
+
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_indexd_test_database(request):
+    """Set up the database to be used for the tests.
+
+    autouse: every test runs this fixture, without calling it directly
+    session scope: all tests share the same fixture
+
+    Basically this only runs once at the beginning of the full test run. This
+    sets up the test database and test user to use for the rest of the tests.
+    """
+
+    # try_drop_test_data() is run before the tests starts and after the tests
+    # complete. This ensures a clean database on start and end of the tests.
+    setup_database()
+    request.addfinalizer(try_drop_test_data)
+
+
+def truncate_tables(driver, base):
+    """Drop all the tables in this application's scope.
+
+    This has the same effect as deleting the sqlite file. Your test will have a
+    fresh database for it's run.
+    """
+
+    # Drop tables in reverse order to avoid cascade drop errors.
+    # metadata is a sqlalchemy property.
+    # sorted_tables is a list of tables sorted by their dependencies.
+    with driver.engine.begin() as txn:
+        for table in reversed(base.metadata.sorted_tables):
+            # do not clear schema versions so each test does not re-trigger migration.
+            if table.name not in ["index_schema_version", "alias_schema_version"]:
+                txn.execute("TRUNCATE {} CASCADE;".format(table.name))
+
+
+@pytest.fixture
+def index_driver():
+    driver = SQLAlchemyIndexDriver(PG_URL, auto_migrate=False)
+    yield driver
+    truncate_tables(driver, index_base)
+    driver.dispose()
+
+
+@pytest.fixture
+def alias_driver():
+    driver = SQLAlchemyAliasDriver(PG_URL, auto_migrate=False)
+    yield driver
+    truncate_tables(driver, alias_base)
+    driver.dispose()
+
+
+@pytest.fixture(scope="session")
+def auth_driver():
+    driver = SQLAlchemyAuthDriver(PG_URL)
+    yield driver
+    driver.dispose()
+
+
+@pytest.fixture
+def indexd_admin_user(auth_driver):
+    username = password = "admin"
+    auth_driver.add(username, password)
+    yield username, password
+    auth_driver.delete("admin")
+
+
+@pytest.fixture
+def index_driver_no_migrate():
+    """
+    This fixture is designed for testing migration scripts and can be used for
+    any other situation where a migration is not desired on instantiation.
+    """
+    driver = SQLAlchemyIndexDriver(PG_URL, auto_migrate=False)
+    yield driver
+    truncate_tables(driver, index_base)
+    driver.dispose()
+
+
+@pytest.fixture
+def alias_driver_no_migrate():
+    """
+    This fixture is designed for testing migration scripts and can be used for
+    any other situation where a migration is not desired on instantiation.
+    """
+    driver = SQLAlchemyAliasDriver(PG_URL, auto_migrate=False)
+    yield driver
+    truncate_tables(driver, alias_base)
+    driver.dispose()
+
+
+@pytest.fixture
+def create_indexd_tables(index_driver, alias_driver, auth_driver):
+    """Make sure the tables are created but don't operate on them directly.
+    Also set up the password to be accessed by the client tests.
+    Migration not required as tables will be created with most recent models
+    """
+    pass
+
+
+@pytest.fixture
+def create_indexd_tables_no_migrate(
+        index_driver_no_migrate, alias_driver_no_migrate, auth_driver):
+    """Make sure the tables are created but don't operate on them directly.
+
+    There is no migration required for the SQLAlchemyAuthDriver.
+    Also set up the password to be accessed by the client tests.
+    """
+    pass
+
+
+@pytest.fixture
+def indexd_client(indexd_server, create_indexd_tables, indexd_admin_user):
+    """Create the tables and add an auth user"""
+    return IndexClient(indexd_server.baseurl, auth=(indexd_admin_user[0], indexd_admin_user[1]))
+
+
+@pytest.fixture(scope='session')
+def indexd_server():
+    """
+    Starts the indexd server, and cleans up its mess.
+    Most tests will use the client which stems from this
+    server fixture.
+
+    Runs once per test session.
+    """
+    app = get_app()
+    hostname = 'localhost'
+    port = 8001
+    debug = False
+    t = threading.Thread(target=app.run, kwargs={'host': hostname, 'port': port, 'debug': debug})
+    t.setDaemon(True)
+    t.start()
+    wait_for_indexd_alive(port)
+    yield MockServer(port=port)
+
+
+def wait_for_indexd_alive(port):
+    url = 'http://localhost:{}'.format(port)
+    try:
+        requests.get(url)
+    except requests.ConnectionError:
+        return wait_for_indexd_alive(port)
+    else:
+        return
+
+
+class MockServer(object):
+    def __init__(self, port):
+        self.port = port
+        self.baseurl = 'http://localhost:{}'.format(port)
+
+
+def create_random_index(index_client, did=None, version=None, hashes=None):
+    """
+    Shorthand for creating new index entries for test purposes.
+    Note:
+        Expects index client v1.5.2 and above
+    Args:
+        index_client (indexclient.client.IndexClient): pytest fixture for index_client
+        passed from actual test functions
+        did (str): if specified it will be used as document did, else allows indexd to create one
+        version (str): version of the index being added
+        hashes (dict): hashes to store on the index, if not specified a random one is created
+    Returns:
+        indexclient.client.Document: the document just created
+    """
+
+    did = str(uuid.uuid4()) if did is None else did
+
+    if not hashes:
+        md5_hasher = hashlib.md5()
+        md5_hasher.update(did.encode("utf-8"))
+        hashes = {'md5': md5_hasher.hexdigest()}
+
+    doc = index_client.create(
+        did=did,
+        hashes=hashes,
+        size=random.randint(10, 1000),
+        version=version,
+        acl=["a", "b"],
+        file_name="{}_warning_huge_file.svs".format(did),
+        urls=["s3://super-safe.com/{}_warning_huge_file.svs".format(did)],
+        urls_metadata={"s3://super-safe.com/{}_warning_huge_file.svs".format(did): {"a": "b"}}
+    )
+
+    return doc
+
+
+def create_random_index_version(index_client, did, version_did=None, version=None):
+    """
+    Shorthand for creating a dummy version of an existing index, use wisely as it does not assume any versioning
+    scheme and null versions are allowed
+    Args:
+        index_client (IndexClient): pytest fixture for index_client
+        passed from actual test functions
+        did (str): existing member did
+        version_did (str): did for the version to be created
+        version (str): version number for the version to be created
+    Returns:
+        Document: the document just created
+    """
+    md5_hasher = hashlib.md5()
+    md5_hasher.update(did.encode("utf-8"))
+    file_name = did
+
+    data = {}
+    if version_did:
+        data["did"] = version_did
+        file_name = version_did
+        md5_hasher.update(version_did.encode("utf-8"))
+
+    data["acl"] = ["ax", "bx"]
+    data["size"] = random.randint(10, 1000)
+    data["hashes"] = {"md5": md5_hasher.hexdigest()}
+    data["urls"] = ["s3://super-safe.com/{}_warning_huge_file.svs".format(file_name)]
+    data["form"] = "object"
+    data["file_name"] = "{}_warning_huge_file.svs".format(file_name)
+    data["urls_metadata"] = {
+        "s3://super-safe.com/{}_warning_huge_file.svs".format(file_name): {"a": "b"}
+    }
+
+    if version:
+        data["version"] = version
+
+    doc = index_client.add_version(did, Document(None, None, data))
+
+    want_filename = "{}_warning_huge_file.svs".format(file_name)
+    want_url = 's3://super-safe.com/' + want_filename
+
+    assert doc
+    assert sorted(doc.acl) == ['ax', 'bx']
+    assert doc.size
+    assert doc.hashes.get('md5')
+    assert doc.urls[0] == want_url
+    assert doc.form == 'object'
+    assert doc.file_name == want_filename
+    assert doc.urls_metadata.get(want_url) == {'a': 'b'}
+    if version:
+        assert doc.version == version
+
+    return doc

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist= py27, py35, py36, py37
 deps=
     -rdev-requirements.txt
 
+install_command = python -m pip install --no-deps {opts} {packages}
+
 commands=
     pip install . --force --upgrade
     python -m pytest {posargs: -lvvvs tests}

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ deps=
     -rdev-requirements.txt
 
 commands=
+    pip install --upgrade pip
     pip install . --force --upgrade
     python -m pytest {posargs: -lvvvs tests}

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,5 @@ deps=
     -rdev-requirements.txt
 
 commands=
-    pip install --upgrade pip
     pip install . --force --upgrade
     python -m pytest {posargs: -lvvvs tests}


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DEV-556

To remove indexd-indexclient circular dependency, move index_test_utils to indexclient. 

After merged and tagged this services need to update their indexclient pin
Graph manager
Data-tools
Gdcapi
Esbuild
Sheepdog
Runners
Gdcadmin
Ancillary-services