### PR TITLE
DEV-1062: Add not deleted parameter to query url functions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,9 +162,9 @@
         "filename": "tests/test_client.py",
         "hashed_secret": "cddba27a55fead7ca013f34a28d465f71403af5d",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 247
       }
     ]
   },
-  "generated_at": "2022-03-18T23:03:51Z"
+  "generated_at": "2022-03-23T21:23:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,9 +162,9 @@
         "filename": "tests/test_client.py",
         "hashed_secret": "cddba27a55fead7ca013f34a28d465f71403af5d",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 239
       }
     ]
   },
-  "generated_at": "2022-02-08T22:28:40Z"
+  "generated_at": "2022-03-18T23:03:51Z"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 
 python:

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,7 +10,7 @@ cfgv~=2.0.1
 more-itertools<6
 
 git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.2#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@d6c94f259ad15693eb754090909c343080d2580b#egg=indexd
 git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 cdislogging==1.0.0

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,7 +10,7 @@ cfgv~=2.0.1
 more-itertools<6
 
 git+https://github.com/uc-cdis/cdis-python-utils.git@1.0.0#egg=cdispyutils
-git+https://github.com/NCI-GDC/indexd.git@d6c94f259ad15693eb754090909c343080d2580b#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.3#egg=indexd
 git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 cdislogging==1.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-git+https://github.com/NCI-GDC/indexd.git@d6c94f259ad15693eb754090909c343080d2580b#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.3#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -96,7 +96,7 @@ importlib-resources==3.2.1
     # via
     #   pre-commit
     #   virtualenv
-git+https://github.com/NCI-GDC/indexd.git@2.9.0-rc.2#egg=indexd
+git+https://github.com/NCI-GDC/indexd.git@d6c94f259ad15693eb754090909c343080d2580b#egg=indexd
     # via -r dev-requirements.in
 ipaddress==1.0.23
     # via cryptography

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -379,12 +379,16 @@ class IndexClient(object):
             params["limit"] = min(limit, page_size)
             params["offset"] += len(response)
 
-    def query_url(self, exclude=None, include=None, versioned=False, fields=None, limit=100, offset=0, page_size=100):
+    def query_url(
+            self, exclude=None, include=None, versioned=False, exclude_deleted=False, fields=None, limit=100, offset=0,
+            page_size=100
+    ):
         """ Queries indexd entries using URL patterns, which can be either full or partial URLs
         Args:
             exclude (str): A URL pattern to exclude. All URLs matching this pattern will not be included in the return
             include (str): All entries with URL matching this pattern will be included
-            versioned (str): whether or not is versioned
+            versioned (bool): whether or not is versioned
+            exclude_deleted (bool): if True, excludes deleted docs from search
             fields: (str): comma separated list of fields to return
             limit: (int): max results to return
             offset: (int) where to start the next query from
@@ -396,6 +400,7 @@ class IndexClient(object):
             "exclude": exclude,
             "include": include,
             "versioned": versioned,
+            "exclude_deleted": exclude_deleted,
             "fields": fields,
             "limit": limit if limit < page_size else page_size,
             "offset": offset

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -325,17 +325,17 @@ class IndexClient(object):
             return Document(self, rev_doc["did"])
         return None
 
-    def list_versions(self, did, skip_deleted_versions=True):
+    def list_versions(self, did, exclude_deleted=False):
         """
         Get all record versions given did
         Args:
             did (str): document id of an existing record
-            skip_deleted_versions (bool): if True, exclude records marked as deleted in metadata
+            exclude_deleted (bool): if True, exclude records marked as deleted in metadata
         Returns:
             list: Document versions
         """
 
-        params = {"not_deleted": json.dumps(skip_deleted_versions)}
+        params = {"exclude_deleted": json.dumps(exclude_deleted)}
 
         versions_dict = self._get("index", did, "versions", params=params).json()  # type: dict
         versions = []

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -289,20 +289,20 @@ class IndexClient(object):
         resp = self._put(url, headers=headers, data=data, auth=self.auth)
         return resp.json()
 
-    def get_latest_version(self, did, skip_null_versions=False, skip_deleted_versions=True):
+    def get_latest_version(self, did, skip_null_versions=False, exclude_deleted=False):
         """
         Get the latest version given did
         Args:
             did (str): document id of an existing entry whose latest version is requested
             skip_null_versions (bool): if True, exclude entries without a version
-            skip_deleted_versions (bool): if True, exclude entries marked as deleted in metadata
+            exclude_deleted (bool): if True, exclude entries marked as deleted in metadata
         Returns:
             Document: latest version of the entry
         """
 
         params = {
             "has_version": json.dumps(skip_null_versions),
-            "not_deleted": json.dumps(skip_deleted_versions),
+            "exclude_deleted": json.dumps(exclude_deleted),
         }
         doc = self._get("index", did, "latest", params=params).json()
 

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -344,13 +344,17 @@ class IndexClient(object):
             versions.append(Document(self, version["did"], version))
         return versions
 
-    def query_urls_metadata(self, url, key, value, fields=None, versioned=False, limit=100, offset=0, page_size=100):
+    def query_urls_metadata(
+            self, url, key, value, fields=None, versioned=False, exclude_deleted=False, limit=100, offset=0,
+            page_size=100
+    ):
         """ Queries indexd entries using URL patterns, which can be either full or partial URLs
         Args:
             url (str): A URL pattern to match
             key (str): metadata key
             value (str): metadata value for key
-            versioned (str): whether or not is versioned
+            versioned (bool): whether or not is versioned
+            exclude_deleted (bool): If true, exclude deleted documents from search
             fields: (str): comma separated list of fields to return
             limit: (int): max results to return
             offset: (int) where to start the next query from
@@ -364,6 +368,7 @@ class IndexClient(object):
             "value": value,
             "fields": fields,
             "versioned": versioned,
+            "exclude_deleted": exclude_deleted,
             "limit": limit if limit < page_size else page_size,
             "offset": offset
         }

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -119,13 +119,13 @@ class IndexClient(object):
             for doc in response.json()
         ]
 
-    def bulk_get_latest(self, dids, skip_null=False, skip_deleted=True):
+    def bulk_get_latest(self, dids, skip_null=False, exclude_deleted=False):
         """
         bulk get latest version
         Args:
             dids (list): list of dids
             skip_null (bool): skip null versions
-            skip_deleted (bool): skip deleted versions
+            exclude_deleted (bool): exclude deleted versions
 
         Returns:
             list: Document objects
@@ -135,7 +135,7 @@ class IndexClient(object):
         try:
             response = self._post(
                 "bulk/documents/latest",
-                params={"skip_null": skip_null, "skip_deleted": skip_deleted},
+                params={"skip_null": skip_null, "exclude_deleted": exclude_deleted},
                 json=dids,
                 headers=headers
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -361,7 +361,7 @@ def test_query_urls__include(indexd_loader, indexd_client, include, expectation)
 
 
 def test_query_url_exclude_deleted(index_client):
-    """ Tests query_urls() with the exclude_deleted parameter """
+    """ Tests query_url() with the exclude_deleted parameter """
     total_count = 0
     deleted_count = 0
 
@@ -395,3 +395,31 @@ def test_query_urls_metadata(indexd_loader, indexd_client, params, expected):
     urls = indexd_client.query_urls_metadata(**params)
 
     assert expected == len(list(urls))
+
+
+def test_query_urls_metadata_exclude_deleted(index_client):
+    """ Tests query_urls_metadata() with the exclude_deleted parameter """
+
+    # all docs created with create_random_index() have a url matching this pattern and a corresponding key-value pair
+    url_match = "s3://super-safe.com/"
+    key = "a"
+    value = "b"
+
+    total_count = 0
+    deleted_count = 0
+
+    for i in range(10):
+        doc = create_random_index(index_client)
+
+        if i % 2 == 0:
+            total_count += 1
+        else:
+            doc.metadata = {"deleted": "True"}
+            doc.patch()
+            deleted_count += 1
+            total_count += 1
+
+    assert len(list(index_client.query_urls_metadata(url=url_match, key=key, value=value))) == total_count
+    assert len(
+        list(index_client.query_urls_metadata(url=url_match, key=key, value=value, exclude_deleted=True))
+    ) == total_count - deleted_count

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,9 +106,9 @@ def test_get_latest_version_with_skip(index_client):
     assert v_doc.baseid == doc_2.baseid
 
 
-def test_get_latest_version_with_skip_deleted(index_client):
+def test_get_latest_version_with_exclude_deleted(index_client):
     """
-    Tests retrieval of latest record version not flagged as deleted
+    Tests retrieval of latest record version using exclude_deleted parameter
     Args:
         index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
     """
@@ -119,8 +119,8 @@ def test_get_latest_version_with_skip_deleted(index_client):
     deleted_doc.metadata = {"deleted": "True"}
     deleted_doc.patch()
 
-    assert non_deleted_doc == index_client.get_latest_version(did)
-    assert deleted_doc == index_client.get_latest_version(did, skip_deleted_versions=False)
+    assert non_deleted_doc == index_client.get_latest_version(did, exclude_deleted=True)
+    assert deleted_doc == index_client.get_latest_version(did)
 
 
 @pytest.mark.parametrize("arg, exception", [("AAA", HTTPError), (None, TypeError)])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,9 +169,9 @@ def test_list_versions(index_client):
     assert len(versions) == 2
 
 
-def test_list_versions_with_delete(index_client):
+def test_list_versions_with_exclude_deleted(index_client):
     """
-    Tests retrieval of all versions of document not flagged as deleted
+    Tests retrieval of all versions of document using exclude_deleted parameter
     Args:
         index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
     """
@@ -191,9 +191,9 @@ def test_list_versions_with_delete(index_client):
             doc.patch()
             deleted_docs.append(doc)
 
-    assert set(index_client.list_versions(did, skip_deleted_versions=False)) == set(non_deleted_docs + deleted_docs), \
+    assert set(index_client.list_versions(did)) == set(non_deleted_docs + deleted_docs), \
         "the versions returned do not match all records created"
-    assert set(index_client.list_versions(did)) == set(non_deleted_docs), \
+    assert set(index_client.list_versions(did, exclude_deleted=True)) == set(non_deleted_docs), \
         "the versions returned do not match non-deleted records created"
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,10 +107,14 @@ def test_get_latest_version_with_skip(index_client):
 
 
 def test_get_latest_version_with_exclude_deleted(index_client):
-    """
-    Tests retrieval of latest record version using exclude_deleted parameter
+    """Test retrieval of latest record version using exclude_deleted param.
+
+    This test creates two documents, a primary document with default values
+    and then a deleted version of this document. It then verifies that using
+    the exclude_deleted parameter gets the correct version of the document.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     non_deleted_doc = create_random_index(index_client)
     did = non_deleted_doc.did
@@ -170,10 +174,14 @@ def test_list_versions(index_client):
 
 
 def test_list_versions_with_exclude_deleted(index_client):
-    """
-    Tests retrieval of all versions of document using exclude_deleted parameter
+    """Test retrieval of all versions of a doc using exclude_deleted param.
+
+    This test creates a version hierarchy of documents with some marked as
+    deleted. It then verifies that using the exclude_deleted parameter filters
+    deleted documents from the results.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     doc = create_random_index(index_client)
     did = doc.did
@@ -303,10 +311,15 @@ def test_bulk_get_latest_with_skip_null(index_client):
 
 
 def test_bulk_get_latest_with_exclude_deleted(index_client):
-    """
-    Tests bulk_get_latest() with exclude_deleted parameter
+    """Test bulk retrieval of latest versions of docs using exclude_deleted.
+
+    This test creates several version hierarchies of documents with the latest
+    versions in each hierarchy marked as deleted. It then verifies that using
+    the exclude_deleted parameter returns the correct latest version of docs
+    in each hierarchy.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     dids = []
     latest_non_deleted_dids = set()
@@ -369,10 +382,14 @@ def test_query_urls__include(indexd_loader, indexd_client, include, expectation)
 
 
 def test_query_url_exclude_deleted(index_client):
-    """
-    Tests query_url() with exclude_deleted parameter
+    """Test doc retrieval using the query_url exclude_deleted param.
+
+    This test creates several documents, marking some documents as deleted.
+    It then verifies that using the exclude_deleted parameter filters out the
+    deleted documents.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     non_deleted_count = 0
     deleted_count = 0
@@ -412,10 +429,14 @@ def test_query_urls_metadata(indexd_loader, indexd_client, params, expected):
 
 
 def test_query_urls_metadata_exclude_deleted(index_client):
-    """
-    Tests query_urls_metadata() with exclude_deleted parameter
+    """Test doc retrieval using the query_urls_metadata exclude_deleted param.
+
+    This test creates several documents, marking some documents as deleted.
+    It then verifies that using the exclude_deleted parameter filters out the
+    deleted documents.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
 
     # all docs created with create_random_index() have a url matching this pattern and a corresponding key-value pair

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -301,8 +301,8 @@ def test_bulk_get_latest_with_skip_null(index_client):
     assert {doc.did for doc in docs_null_included} == null_dids
 
 
-def test_bulk_get_latest_with_skip_deleted(index_client):
-    """ Test bulk_get_latest() with skip_deleted parameters """
+def test_bulk_get_latest_with_exclude_deleted(index_client):
+    """ Test bulk_get_latest() with exclude_deleted parameter """
     dids = []
     new_dids = set()
     deleted_dids = set()
@@ -320,8 +320,8 @@ def test_bulk_get_latest_with_skip_deleted(index_client):
         new_dids.add(rev_doc.did)
         deleted_dids.add(deleted_doc.did)
 
-    docs_deleted_excluded = index_client.bulk_get_latest(dids, skip_deleted=True)
-    docs_deleted_included = index_client.bulk_get_latest(dids, skip_deleted=False)
+    docs_deleted_excluded = index_client.bulk_get_latest(dids, exclude_deleted=True)
+    docs_deleted_included = index_client.bulk_get_latest(dids)
     assert {doc.did for doc in docs_deleted_excluded} == new_dids
     assert {doc.did for doc in docs_deleted_included} == deleted_dids
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -191,10 +191,11 @@ def test_list_versions_with_exclude_deleted(index_client):
             doc.patch()
             deleted_docs.append(doc)
 
-    assert set(index_client.list_versions(did)) == set(non_deleted_docs + deleted_docs), \
-        "the versions returned do not match all records created"
-    assert set(index_client.list_versions(did, exclude_deleted=True)) == set(non_deleted_docs), \
-        "the versions returned do not match non-deleted records created"
+    includes_deleted = index_client.list_versions(did)
+    assert set(includes_deleted) == set(non_deleted_docs + deleted_docs)
+
+    excludes_deleted = index_client.list_versions(did, exclude_deleted=True)
+    assert set(excludes_deleted) == set(non_deleted_docs)
 
 
 def test_updating_metadata(index_client):
@@ -302,28 +303,35 @@ def test_bulk_get_latest_with_skip_null(index_client):
 
 
 def test_bulk_get_latest_with_exclude_deleted(index_client):
-    """ Test bulk_get_latest() with exclude_deleted parameter """
+    """
+    Tests bulk_get_latest() with exclude_deleted parameter
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+    """
     dids = []
-    new_dids = set()
-    deleted_dids = set()
+    latest_non_deleted_dids = set()
+    latest_dids = set()
+
     for i in range(20):
         doc = create_random_index(index_client)
         rev_doc = create_random_index_version(index_client, did=doc.did)
+        latest_non_deleted_dids.add(rev_doc.did)
+
         if i < 5:
-            deleted_doc = create_random_index_version(index_client, did=doc.did)
-            deleted_doc.metadata = {"deleted": "True"}
-            deleted_doc.patch()
+            latest_doc = create_random_index_version(index_client, did=doc.did)
+            latest_doc.metadata = {"deleted": "True"}
+            latest_doc.patch()
         else:
-            deleted_doc = rev_doc
+            latest_doc = rev_doc
 
         dids.append(doc.did)
-        new_dids.add(rev_doc.did)
-        deleted_dids.add(deleted_doc.did)
+        latest_dids.add(latest_doc.did)
 
-    docs_deleted_excluded = index_client.bulk_get_latest(dids, exclude_deleted=True)
-    docs_deleted_included = index_client.bulk_get_latest(dids)
-    assert {doc.did for doc in docs_deleted_excluded} == new_dids
-    assert {doc.did for doc in docs_deleted_included} == deleted_dids
+    includes_deleted = index_client.bulk_get_latest(dids)
+    assert set(doc.did for doc in includes_deleted) == latest_dids
+
+    excludes_deleted = index_client.bulk_get_latest(dids, exclude_deleted=True)
+    assert set(doc.did for doc in excludes_deleted) == latest_non_deleted_dids
 
 
 @pytest.mark.parametrize("exclude, expectation", [
@@ -361,23 +369,29 @@ def test_query_urls__include(indexd_loader, indexd_client, include, expectation)
 
 
 def test_query_url_exclude_deleted(index_client):
-    """ Tests query_url() with the exclude_deleted parameter """
-    total_count = 0
+    """
+    Tests query_url() with exclude_deleted parameter
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+    """
+    non_deleted_count = 0
     deleted_count = 0
 
     for i in range(10):
         doc = create_random_index(index_client)
 
         if i % 2 == 0:
-            total_count += 1
+            non_deleted_count += 1
         else:
             doc.metadata = {"deleted": "True"}
             doc.patch()
             deleted_count += 1
-            total_count += 1
 
-    assert len(list(index_client.query_url())) == total_count
-    assert len(list(index_client.query_url(exclude_deleted=True))) == total_count - deleted_count
+    includes_deleted = list(index_client.query_url())
+    assert len(includes_deleted) == non_deleted_count + deleted_count
+
+    excludes_deleted = list(index_client.query_url(exclude_deleted=True))
+    assert len(excludes_deleted) == non_deleted_count
 
 
 @pytest.mark.parametrize("params, expected", [
@@ -398,28 +412,32 @@ def test_query_urls_metadata(indexd_loader, indexd_client, params, expected):
 
 
 def test_query_urls_metadata_exclude_deleted(index_client):
-    """ Tests query_urls_metadata() with the exclude_deleted parameter """
+    """
+    Tests query_urls_metadata() with exclude_deleted parameter
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+    """
 
     # all docs created with create_random_index() have a url matching this pattern and a corresponding key-value pair
     url_match = "s3://super-safe.com/"
     key = "a"
     value = "b"
 
-    total_count = 0
+    non_deleted_count = 0
     deleted_count = 0
 
     for i in range(10):
         doc = create_random_index(index_client)
 
         if i % 2 == 0:
-            total_count += 1
+            non_deleted_count += 1
         else:
             doc.metadata = {"deleted": "True"}
             doc.patch()
             deleted_count += 1
-            total_count += 1
 
-    assert len(list(index_client.query_urls_metadata(url=url_match, key=key, value=value))) == total_count
-    assert len(
-        list(index_client.query_urls_metadata(url=url_match, key=key, value=value, exclude_deleted=True))
-    ) == total_count - deleted_count
+    includes_deleted = list(index_client.query_urls_metadata(url=url_match, key=key, value=value))
+    assert len(includes_deleted) == non_deleted_count + deleted_count
+
+    excludes_deleted = list(index_client.query_urls_metadata(url=url_match, key=key, value=value, exclude_deleted=True))
+    assert len(excludes_deleted) == deleted_count

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -360,6 +360,26 @@ def test_query_urls__include(indexd_loader, indexd_client, include, expectation)
     assert expectation == total_urls
 
 
+def test_query_url_exclude_deleted(index_client):
+    """ Tests query_urls() with the exclude_deleted parameter """
+    total_count = 0
+    deleted_count = 0
+
+    for i in range(10):
+        doc = create_random_index(index_client)
+
+        if i % 2 == 0:
+            total_count += 1
+        else:
+            doc.metadata = {"deleted": "True"}
+            doc.patch()
+            deleted_count += 1
+            total_count += 1
+
+    assert len(list(index_client.query_url())) == total_count
+    assert len(list(index_client.query_url(exclude_deleted=True))) == total_count - deleted_count
+
+
 @pytest.mark.parametrize("params, expected", [
     ({"url":"s3://localhost:7000/test_bucket_2", "key":"type", "value":"aws", "page_size":2}, 4),
     ({"url":"s3://localhost:7000/test_bucket", "key":"type", "value":"cleversafe", "page_size":3}, 5),


### PR DESCRIPTION
This has been replaced by the following PR and is being kept for reference until that PR is approved: https://github.com/NCI-GDC/indexclient/pull/38

Includes the following changes:

- Update indexd dependency
- Add exclude_deleted parameter to query url functions
- Update existing functions with a deleted parameter (get_latest_version, list_versions, bulk_get_latest) to use the new naming convention (exclude_deleted vs not_deleted or skip_deleted) and set default to False
