### PR TITLE
DEV-1026: Add exclude_deleted params and test cases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "tests/integration/test_client.py",
         "hashed_secret": "b1446dd542cd1725f1c2a1a43905355cd31c039f",
         "is_verified": false,
-        "line_number": 240,
+        "line_number": 245,
         "is_secret": true
       },
       {
@@ -221,10 +221,10 @@
         "filename": "tests/integration/test_client.py",
         "hashed_secret": "cddba27a55fead7ca013f34a28d465f71403af5d",
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 248,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2023-02-03T18:26:54Z"
+  "generated_at": "2023-03-01T23:38:38Z"
 }

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -117,13 +117,13 @@ class IndexClient:
 
         return [Document(self, doc["did"], json=doc) for doc in response.json()]
 
-    def bulk_get_latest(self, dids, skip_null=False, skip_deleted=True):
+    def bulk_get_latest(self, dids, skip_null=False, exclude_deleted=False):
         """
         bulk get latest version
         Args:
             dids (list): list of dids
             skip_null (bool): skip null versions
-            skip_deleted (bool): skip deleted versions
+            exclude_deleted (bool): exclude deleted versions
 
         Returns:
             list: Document objects
@@ -133,7 +133,7 @@ class IndexClient:
         try:
             response = self._post(
                 "bulk/documents/latest",
-                params={"skip_null": skip_null, "exclude_deleted": skip_deleted},
+                params={"skip_null": skip_null, "exclude_deleted": exclude_deleted},
                 json=dids,
                 headers=headers,
             )
@@ -313,22 +313,20 @@ class IndexClient:
         resp = self._put(url, headers=headers, data=data, auth=self.auth)
         return resp.json()
 
-    def get_latest_version(
-        self, did, skip_null_versions=False, skip_deleted_versions=True
-    ):
+    def get_latest_version(self, did, skip_null_versions=False, exclude_deleted=False):
         """
         Get the latest version given did
         Args:
             did (str): document id of an existing entry whose latest version is requested
             skip_null_versions (bool): if True, exclude entries without a version
-            skip_deleted_versions (bool): if True, exclude entries marked as deleted in metadata
+            exclude_deleted (bool): if True, exclude entries marked as deleted in metadata
         Returns:
             Document: latest version of the entry
         """
 
         params = {
             "has_version": json.dumps(skip_null_versions),
-            "exclude_deleted": json.dumps(skip_deleted_versions),
+            "exclude_deleted": json.dumps(exclude_deleted),
         }
         doc = self._get("index", did, "latest", params=params).json()
 
@@ -353,17 +351,17 @@ class IndexClient:
             return Document(self, rev_doc["did"])
         return None
 
-    def list_versions(self, did, skip_deleted_versions=True):
+    def list_versions(self, did, exclude_deleted=False):
         """
         Get all record versions given did
         Args:
             did (str): document id of an existing record
-            skip_deleted_versions (bool): if True, exclude records marked as deleted in metadata
+            exclude_deleted (bool): if True, exclude records marked as deleted in metadata
         Returns:
             list: Document versions
         """
 
-        params = {"exclude_deleted": json.dumps(skip_deleted_versions)}
+        params = {"exclude_deleted": json.dumps(exclude_deleted)}
 
         versions_dict = self._get(
             "index", did, "versions", params=params
@@ -381,6 +379,7 @@ class IndexClient:
         value,
         fields=None,
         versioned=False,
+        exclude_deleted=False,
         limit=100,
         offset=0,
         page_size=100,
@@ -390,7 +389,8 @@ class IndexClient:
             url (str): A URL pattern to match
             key (str): metadata key
             value (str): metadata value for key
-            versioned (str): whether or not is versioned
+            versioned (bool): whether or not is versioned
+            exclude_deleted (bool): If true, exclude deleted documents from search
             fields: (str): comma separated list of fields to return
             limit: (int): max results to return
             offset: (int) where to start the next query from
@@ -404,6 +404,7 @@ class IndexClient:
             "value": value,
             "fields": fields,
             "versioned": versioned,
+            "exclude_deleted": exclude_deleted,
             "limit": limit if limit < page_size else page_size,
             "offset": offset,
         }
@@ -423,6 +424,7 @@ class IndexClient:
         exclude=None,
         include=None,
         versioned=False,
+        exclude_deleted=False,
         fields=None,
         limit=100,
         offset=0,
@@ -432,7 +434,8 @@ class IndexClient:
         Args:
             exclude (str): A URL pattern to exclude. All URLs matching this pattern will not be included in the return
             include (str): All entries with URL matching this pattern will be included
-            versioned (str): whether or not is versioned
+            versioned (bool): whether or not is versioned
+            exclude_deleted (bool): if True, excludes deleted docs from search
             fields: (str): comma separated list of fields to return
             limit: (int): max results to return
             offset: (int) where to start the next query from
@@ -444,6 +447,7 @@ class IndexClient:
             "exclude": exclude,
             "include": include,
             "versioned": versioned,
+            "exclude_deleted": exclude_deleted,
             "fields": fields,
             "limit": limit if limit < page_size else page_size,
             "offset": offset,

--- a/pytest_indexd/utils.py
+++ b/pytest_indexd/utils.py
@@ -52,10 +52,7 @@ def mock_doc(doc: IndexData) -> IndexData:
         doc["acl"] = ["open"]
     if "urls_metadata" not in doc:
         doc["urls_metadata"] = {
-            f"s3://ceph.service.consul/data-tools/{doc['did']}_test_file.svs": {
-                "type": "cleversafe",
-                "state": "validated",
-            }
+            f"s3://super-safe.com/{doc['did']}_warning_huge_file.svs": {"a": "b"}
         }
     if "urls" not in doc:
         doc["urls"] = list(doc.get("urls_metadata", {}).keys())

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -105,11 +105,15 @@ def test_get_latest_version_with_skip(index_client):
     assert v_doc.baseid == doc_2.baseid
 
 
-def test_get_latest_version_with_skip_deleted(index_client):
-    """
-    Tests retrieval of latest record version not flagged as deleted
+def test_get_latest_version_with_exclude_deleted(index_client):
+    """Test retrieval of latest record version using exclude_deleted param.
+
+    This test creates two documents, a primary document with default values
+    and then a deleted version of this document. It then verifies that using
+    the exclude_deleted parameter gets the correct version of the document.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     non_deleted_doc = create_random_index(index_client)
     did = non_deleted_doc.did
@@ -118,10 +122,8 @@ def test_get_latest_version_with_skip_deleted(index_client):
     deleted_doc.metadata = {"deleted": "True"}
     deleted_doc.patch()
 
-    assert non_deleted_doc == index_client.get_latest_version(did)
-    assert deleted_doc == index_client.get_latest_version(
-        did, skip_deleted_versions=False
-    )
+    assert non_deleted_doc == index_client.get_latest_version(did, exclude_deleted=True)
+    assert deleted_doc == index_client.get_latest_version(did)
 
 
 @pytest.mark.parametrize("arg, exception", [("AAA", HTTPError), (None, TypeError)])
@@ -170,11 +172,15 @@ def test_list_versions(index_client):
     assert len(versions) == 2
 
 
-def test_list_versions_with_delete(index_client):
-    """
-    Tests retrieval of all versions of document not flagged as deleted
+def test_list_versions_with_exclude_deleted(index_client):
+    """Test retrieval of all versions of a doc using exclude_deleted param.
+
+    This test creates a version hierarchy of documents with some marked as
+    deleted. It then verifies that using the exclude_deleted parameter filters
+    deleted documents from the results.
+
     Args:
-        index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
+        index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     doc = create_random_index(index_client)
     did = doc.did
@@ -192,12 +198,11 @@ def test_list_versions_with_delete(index_client):
             doc.patch()
             deleted_docs.append(doc)
 
-    assert set(index_client.list_versions(did, skip_deleted_versions=False)) == set(
-        non_deleted_docs + deleted_docs
-    ), "the versions returned do not match all records created"
-    assert set(index_client.list_versions(did)) == set(
-        non_deleted_docs
-    ), "the versions returned do not match non-deleted records created"
+    includes_deleted = index_client.list_versions(did)
+    assert set(includes_deleted) == set(non_deleted_docs + deleted_docs)
+
+    excludes_deleted = index_client.list_versions(did, exclude_deleted=True)
+    assert set(excludes_deleted) == set(non_deleted_docs)
 
 
 def test_updating_metadata(index_client):
@@ -305,29 +310,41 @@ def test_bulk_get_latest_with_skip_null(index_client):
     assert {doc.did for doc in docs_null_included} == null_dids
 
 
-def test_bulk_get_latest_with_skip_deleted(index_client):
-    """Test bulk_get_latest() with skip_deleted parameters"""
+def test_bulk_get_latest_with_exclude_deleted(index_client):
+    """Test bulk retrieval of latest versions of docs using exclude_deleted.
+
+    This test creates several version hierarchies of documents with the latest
+    versions in each hierarchy marked as deleted. It then verifies that using
+    the exclude_deleted parameter returns the correct latest version of docs
+    in each hierarchy.
+
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient fixture
+    """
     dids = []
-    new_dids = set()
-    deleted_dids = set()
+    latest_non_deleted_dids = set()
+    latest_dids = set()
+
     for i in range(20):
         doc = create_random_index(index_client)
         rev_doc = create_random_index_version(index_client, did=doc.did)
+        latest_non_deleted_dids.add(rev_doc.did)
+
         if i < 5:
-            deleted_doc = create_random_index_version(index_client, did=doc.did)
-            deleted_doc.metadata = {"deleted": "True"}
-            deleted_doc.patch()
+            latest_doc = create_random_index_version(index_client, did=doc.did)
+            latest_doc.metadata = {"deleted": "True"}
+            latest_doc.patch()
         else:
-            deleted_doc = rev_doc
+            latest_doc = rev_doc
 
         dids.append(doc.did)
-        new_dids.add(rev_doc.did)
-        deleted_dids.add(deleted_doc.did)
+        latest_dids.add(latest_doc.did)
 
-    docs_deleted_excluded = index_client.bulk_get_latest(dids, skip_deleted=True)
-    docs_deleted_included = index_client.bulk_get_latest(dids, skip_deleted=False)
-    assert {doc.did for doc in docs_deleted_excluded} == new_dids
-    assert {doc.did for doc in docs_deleted_included} == deleted_dids
+    includes_deleted = index_client.bulk_get_latest(dids)
+    assert set(doc.did for doc in includes_deleted) == latest_dids
+
+    excludes_deleted = index_client.bulk_get_latest(dids, exclude_deleted=True)
+    assert set(doc.did for doc in excludes_deleted) == latest_non_deleted_dids
 
 
 @pytest.mark.parametrize(
@@ -368,6 +385,36 @@ def test_query_urls__include(indexd_loader, indexd_client, include, expectation)
         assert any([include in url for url in entry["urls"]])
         total_urls += 1
     assert expectation == total_urls
+
+
+def test_query_url_exclude_deleted(index_client):
+    """Test doc retrieval using the query_url exclude_deleted param.
+
+    This test creates several documents, marking some documents as deleted.
+    It then verifies that using the exclude_deleted parameter filters out the
+    deleted documents.
+
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient fixture
+    """
+    non_deleted_count = 0
+    deleted_count = 0
+
+    for i in range(10):
+        doc = create_random_index(index_client)
+
+        if i % 2 == 0:
+            non_deleted_count += 1
+        else:
+            doc.metadata = {"deleted": "True"}
+            doc.patch()
+            deleted_count += 1
+
+    includes_deleted = list(index_client.query_url())
+    assert len(includes_deleted) == non_deleted_count + deleted_count
+
+    excludes_deleted = list(index_client.query_url(exclude_deleted=True))
+    assert len(excludes_deleted) == non_deleted_count
 
 
 @pytest.mark.parametrize(
@@ -430,3 +477,44 @@ def test_query_urls_metadata(indexd_loader, indexd_client, params, expected):
     urls = indexd_client.query_urls_metadata(**params)
 
     assert expected == len(list(urls))
+
+
+def test_query_urls_metadata_exclude_deleted(index_client):
+    """Test doc retrieval using the query_urls_metadata exclude_deleted param.
+
+    This test creates several documents, marking some documents as deleted.
+    It then verifies that using the exclude_deleted parameter filters out the
+    deleted documents.
+
+    Args:
+        index_client (indexclient.client.IndexClient): IndexClient fixture
+    """
+    # all docs created with create_random_index() have a url matching this pattern and a corresponding key-value pair
+    url_match = "s3://ceph.service.consul/"
+    key = "type"
+    value = "cleversafe"
+
+    non_deleted_count = 0
+    deleted_count = 0
+
+    for i in range(10):
+        doc = create_random_index(index_client)
+
+        if i % 2 == 0:
+            non_deleted_count += 1
+        else:
+            doc.metadata = {"deleted": "True"}
+            doc.patch()
+            deleted_count += 1
+
+    includes_deleted = list(
+        index_client.query_urls_metadata(url=url_match, key=key, value=value)
+    )
+    assert len(includes_deleted) == non_deleted_count + deleted_count
+
+    excludes_deleted = list(
+        index_client.query_urls_metadata(
+            url=url_match, key=key, value=value, exclude_deleted=True
+        )
+    )
+    assert len(excludes_deleted) == deleted_count

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -490,9 +490,9 @@ def test_query_urls_metadata_exclude_deleted(index_client):
         index_client (indexclient.client.IndexClient): IndexClient fixture
     """
     # all docs created with create_random_index() have a url matching this pattern and a corresponding key-value pair
-    url_match = "s3://ceph.service.consul/"
-    key = "type"
-    value = "cleversafe"
+    url_match = "s3://super-safe.com/"
+    key = "a"
+    value = "b"
 
     non_deleted_count = 0
     deleted_count = 0


### PR DESCRIPTION
Includes the following changes:
- Add exclude_deleted parameter to query url functions
- Update existing functions with a deleted parameter (get_latest_version, list_versions, bulk_get_latest) to use the new naming convention (exclude_deleted vs not_deleted or skip_deleted) and set default to False