### PR TITLE
DEV-2902 handle hashlib.md5 depending on the version of python being …

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "src/indexd_test_utils/__init__.py",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 84,
         "is_secret": false
       }
     ],
@@ -217,5 +217,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-27T13:42:21Z"
+  "generated_at": "2024-08-12T18:40:25Z"
 }

--- a/src/indexd_test_utils/__init__.py
+++ b/src/indexd_test_utils/__init__.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import random
+import sys
 import threading
 import uuid
 
@@ -191,7 +192,9 @@ def create_random_index(index_client, did=None, version=None, hashes=None):
     did = str(uuid.uuid4()) if did is None else did
 
     if not hashes:
-        md5_hasher = hashlib.md5()
+        md5_hasher = (
+            hashlib.md5() if sys.version_info < (3, 9) else hashlib.md5(usedforsecurity=False)
+        )  # nosec
         md5_hasher.update(did.encode("utf-8"))
         hashes = {"md5": md5_hasher.hexdigest()}
 

--- a/src/pytest_indexd/utils.py
+++ b/src/pytest_indexd/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import random
+import sys
 import uuid
 from typing import Dict, Optional
 
@@ -43,7 +44,10 @@ def mock_doc(doc: IndexData) -> IndexData:
 
     # add dummy md5hash if no hash is specified
     if "hashes" not in doc or doc["hashes"] is None:
-        md5 = hashlib.md5()
+
+        md5 = (
+            hashlib.md5() if sys.version_info < (3, 9) else hashlib.md5(usedforsecurity=False)
+        )  # nosec
         md5.update(doc["did"].encode("utf-8"))
         doc["hashes"] = IndexHash(md5=md5.hexdigest())
     if "size" not in doc:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import pytest
 if os.getenv("USE_PYTEST_INDEXD", "false").lower() == "false":
     import hashlib
     import json
+    import sys
     from typing import List
 
     from indexclient import client
@@ -29,7 +30,11 @@ if os.getenv("USE_PYTEST_INDEXD", "false").lower() == "false":
             for doc in doc_data:
                 # add dummy md5hash if no hash is specified
                 if "hashes" not in doc:
-                    md5 = hashlib.md5()
+                    md5 = (
+                        hashlib.md5()
+                        if sys.version_info < (3, 9)
+                        else hashlib.md5(usedforsecurity=False)
+                    )  # nosec
                     md5.update(doc["did"].encode("utf-8"))
                     doc["hashes"] = {"md5": md5.hexdigest()}
                 doc["urls"] = list(doc.get("urls_metadata", {}).keys())


### PR DESCRIPTION
DEV-2902 hashlib.md5 requires the 'usedforsecurity=False' for md5s not used for security. This flag was introduced in python 3.9. It is a required flag to be run in FIPS mode.